### PR TITLE
Set iconAnchor for map icons

### DIFF
--- a/site/src/main/resources/templates/layout-map.html
+++ b/site/src/main/resources/templates/layout-map.html
@@ -13,27 +13,27 @@
     function buildIcons() {
         let icons = new Map();
         let basePath = "[[${STATIC_HOST} + '/map']]";
-        icons.set('section.championship', L.icon({iconUrl: basePath + '/championship.png'}));
-        icons.set('section.first', L.icon({iconUrl: basePath + '/first.png'}));
-        icons.set('section.second', L.icon({iconUrl: basePath + '/second.png'}));
-        icons.set('section.third', L.icon({iconUrl: basePath + '/third.png'}));
-        icons.set('section.fourth', L.icon({iconUrl: basePath + '/fourth.png'}));
-        icons.set('section.fifth', L.icon({iconUrl: basePath + '/fifth.png'}));
-        icons.set('section.elite', L.icon({iconUrl: basePath + '/elite.png'}));
-        icons.set('section.excellence', L.icon({iconUrl: basePath + '/excellence.png'}));
-        icons.set('status.competing', L.icon({iconUrl: basePath + '/band.png'}));
-        icons.set('status.scratch', L.icon({iconUrl: basePath + '/band.png'}));
-        icons.set('status.extinct', L.icon({iconUrl: basePath + '/extinct.png'}));
-        icons.set('status.youth', L.icon({iconUrl: basePath + '/youth.png'}));
-        icons.set('section.youth', L.icon({iconUrl: basePath + '/youth.png'}));
-        icons.set('status.non-competing', L.icon({iconUrl: basePath + '/non_competing.png'}));
-        icons.set('status.wind-band', L.icon({iconUrl: basePath + '/non_competing.png'}));
-        icons.set('status.salvation-army', L.icon({iconUrl: basePath + '/sa.png'}));
-        icons.set('section.a-grade', L.icon({iconUrl: basePath + '/a_grade.png'}));
-        icons.set('section.b-grade', L.icon({iconUrl: basePath + '/b_grade.png'}));
-        icons.set('section.c-grade', L.icon({iconUrl: basePath + '/c_grade.png'}));
-        icons.set('section.d-grade', L.icon({iconUrl: basePath + '/d_grade.png'}));
-        icons.set('venue', L.icon({iconUrl: basePath + '/venue.png'}));
+        icons.set('section.championship', L.icon({iconUrl: basePath + '/championship.png', iconAnchor: [13, 27]}));
+        icons.set('section.first', L.icon({iconUrl: basePath + '/first.png', iconAnchor: [13, 27]}));
+        icons.set('section.second', L.icon({iconUrl: basePath + '/second.png', iconAnchor: [13, 27]}));
+        icons.set('section.third', L.icon({iconUrl: basePath + '/third.png', iconAnchor: [13, 27]}));
+        icons.set('section.fourth', L.icon({iconUrl: basePath + '/fourth.png', iconAnchor: [13, 27]}));
+        icons.set('section.fifth', L.icon({iconUrl: basePath + '/fifth.png', iconAnchor: [13, 27]}));
+        icons.set('section.elite', L.icon({iconUrl: basePath + '/elite.png', iconAnchor: [13, 27]}));
+        icons.set('section.excellence', L.icon({iconUrl: basePath + '/excellence.png', iconAnchor: [13, 27]}));
+        icons.set('status.competing', L.icon({iconUrl: basePath + '/band.png', iconAnchor: [13, 27]}));
+        icons.set('status.scratch', L.icon({iconUrl: basePath + '/band.png', iconAnchor: [13, 27]}));
+        icons.set('status.extinct', L.icon({iconUrl: basePath + '/extinct.png', iconAnchor: [13, 27]}));
+        icons.set('status.youth', L.icon({iconUrl: basePath + '/youth.png', iconAnchor: [13, 27]}));
+        icons.set('section.youth', L.icon({iconUrl: basePath + '/youth.png', iconAnchor: [13, 27]}));
+        icons.set('status.non-competing', L.icon({iconUrl: basePath + '/non_competing.png', iconAnchor: [13, 27]}));
+        icons.set('status.wind-band', L.icon({iconUrl: basePath + '/non_competing.png', iconAnchor: [13, 27]}));
+        icons.set('status.salvation-army', L.icon({iconUrl: basePath + '/sa.png', iconAnchor: [13, 27]}));
+        icons.set('section.a-grade', L.icon({iconUrl: basePath + '/a_grade.png', iconAnchor: [13, 27]}));
+        icons.set('section.b-grade', L.icon({iconUrl: basePath + '/b_grade.png', iconAnchor: [13, 27]}));
+        icons.set('section.c-grade', L.icon({iconUrl: basePath + '/c_grade.png', iconAnchor: [13, 27]}));
+        icons.set('section.d-grade', L.icon({iconUrl: basePath + '/d_grade.png', iconAnchor: [13, 27]}));
+        icons.set('venue', L.icon({iconUrl: basePath + '/venue.png', iconAnchor: [10, 34]}));
 
         return icons;
     }


### PR DESCRIPTION
Set the [iconAnchor](https://leafletjs.com/reference.html#icon-iconanchor) option for all map icons.

Previously, icons aligned the lat/lon with the upper right pixel. This makes it seem like the positions are moving around when zooming in/out. The values I've set, aligns the "arrow" part of the icons with the lat/lon, providing a more natural user experience.