### PR TITLE
Fix prod deploys: skip managed certificate for the Cloudflare-proxied www hostname

### DIFF
--- a/terraform/app-service.tf
+++ b/terraform/app-service.tf
@@ -75,13 +75,20 @@ resource "azurerm_app_service_custom_hostname_binding" "bbr5" {
   depends_on          = [time_sleep.app_service_dns_wait]
 }
 
+# Managed certificates are only issued for the unproxied non-prod hostnames.
+# The prod hostname (www) is proxied through Cloudflare, so Azure's CNAME
+# validation sees Cloudflare's IPs instead of this app service and always
+# fails with a 400. Prod origin TLS is served by the default
+# *.azurewebsites.net certificate behind the Cloudflare proxy.
 resource "azurerm_app_service_managed_certificate" "bbr5cert" {
+  count                      = terraform.workspace == "prod" ? 0 : 1
   depends_on                 = [cloudflare_record.app_service]
   custom_hostname_binding_id = azurerm_app_service_custom_hostname_binding.bbr5.id
 }
 
 resource "azurerm_app_service_certificate_binding" "bbr5cert" {
+  count               = terraform.workspace == "prod" ? 0 : 1
   hostname_binding_id = azurerm_app_service_custom_hostname_binding.bbr5.id
-  certificate_id      = azurerm_app_service_managed_certificate.bbr5cert.id
+  certificate_id      = azurerm_app_service_managed_certificate.bbr5cert[0].id
   ssl_state           = "SniEnabled"
 }


### PR DESCRIPTION
Hi Tim — first, thank you for Brass Band Results. I'm Robert Munson: I run software projects for a living, I'm involved with the Dublin Silver Band in Ohio, and I serve on the NABBA board, so your site is close to my heart. I'd like to start helping out with the codebase, and I'm opening this PR as an introduction.

**What I noticed:** the `deploy` workflow on `main` has failed on every run since June 21 (the last green prod deploy was Dec 29, 2025 — [example failing run](https://github.com/BrassBandResults/bbr5/actions/runs/31323403357)). The failure is always the same Terraform error:

```
Error: creating/updating App Service Managed Certificate "www.brassbandresults.co.uk" ...
Missing one DNS record: The CNAME record for www.brassbandresults.co.uk must point to
bbr5.azurewebsites.net ... The current A record of the custom domain is 172.67.179.94,104.21.88.125.
```

**Why it happens:** those A records are Cloudflare's. Since `www` is proxied (orange-clouded), Azure's validation for App Service managed certificates resolves the hostname, sees Cloudflare instead of the app service, and returns a 400. For subdomains, managed certs *only* support direct-CNAME validation, so this can never succeed while the proxy is on — and because `terraform apply` dies there, the static-site upload and newman smoke-test steps never run either.

**What this PR does:** issues the managed certificate (and its binding) only for the unproxied non-prod hostnames, where validation still works. For prod, no live behaviour changes: the origin already serves the default `*.azurewebsites.net` certificate for `www` SNI today (easy to check with `openssl s_client -servername www.brassbandresults.co.uk -connect bbr5.azurewebsites.net:443`), with Cloudflare terminating public TLS in front of it. On the next apply, Terraform's refresh will drop the already-missing prod cert from state and the deploy should go green end-to-end.

**Possible follow-up, if you're interested:** for hardened origin TLS (Cloudflare "Full (strict)" mode), the tidy path is a Cloudflare Origin CA certificate generated in Terraform (`tls_private_key` → CSR → `cloudflare_origin_ca_certificate` → `azurerm_app_service_certificate`). It needs one extra secret (a Cloudflare Origin CA key). Happy to do that as a follow-up PR if you'd like.

`terraform fmt -check` and `terraform validate` pass; the full site test suite is green on my machine. I'd genuinely love to help more — I noticed `site/todo.txt` and would be glad to pick up items like `robots.txt`/`sitemap.xml` next if that's useful. Tell me how you prefer contributions and I'll fit in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016m3sgr2jgbcjmnHuosmP4M
