### PR TITLE
Fix 500 on /profile for lapsed Pro subscribers, blocking re-upgrades

### DIFF
--- a/site/src/main/java/uk/co/bbr/services/payments/StripeServiceImpl.java
+++ b/site/src/main/java/uk/co/bbr/services/payments/StripeServiceImpl.java
@@ -34,6 +34,11 @@ public class StripeServiceImpl implements StripeService {
             Map<String, Object> customerParams = new HashMap<>();
             customerParams.put("email", user.getStripeEmail());
             CustomerCollection customers = Customer.list(customerParams);
+            if (customers.getData().isEmpty()) {
+                // the stored stripe email has no matching customer, for example a
+                // subscriber from before a stripe account change
+                return Optional.empty();
+            }
             user.setStripeCustomer(customers.getData().get(0).getId());
 
             Map<String, Object> params = new HashMap<>();
@@ -63,7 +68,10 @@ public class StripeServiceImpl implements StripeService {
             return null;
         }
         Long endDateTime = subscription.get().getCurrentPeriodEnd();
-        return Instant.ofEpochMilli(endDateTime).atZone(ZoneId.systemDefault()).toLocalDate();
+        if (endDateTime == null) {
+            return null;
+        }
+        return Instant.ofEpochSecond(endDateTime).atZone(ZoneId.systemDefault()).toLocalDate();
     }
 
     @Override

--- a/site/src/main/java/uk/co/bbr/web/profile/ProfileController.java
+++ b/site/src/main/java/uk/co/bbr/web/profile/ProfileController.java
@@ -52,8 +52,11 @@ public class ProfileController {
         Subscription subscription = null;
         if (currentUserSubOpt.isPresent())
         {
-            subscriptionExpiryDate = Instant.ofEpochSecond(currentUserSubOpt.get().getCurrentPeriodEnd()).atZone(ZoneId.systemDefault()).toLocalDate();
             subscription = currentUserSubOpt.get();
+            Long currentPeriodEnd = subscription.getCurrentPeriodEnd();
+            if (currentPeriodEnd != null) {
+                subscriptionExpiryDate = Instant.ofEpochSecond(currentPeriodEnd).atZone(ZoneId.systemDefault()).toLocalDate();
+            }
         }
 
         model.addAttribute("User", user);

--- a/site/src/test/java/uk/co/bbr/web/profile/ProfileStripeWebTests.java
+++ b/site/src/test/java/uk/co/bbr/web/profile/ProfileStripeWebTests.java
@@ -1,0 +1,139 @@
+package uk.co.bbr.web.profile;
+
+import com.stripe.model.Subscription;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.security.web.csrf.CsrfTokenRepository;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.client.RestTemplate;
+import uk.co.bbr.services.payments.StripeService;
+import uk.co.bbr.services.security.JwtService;
+import uk.co.bbr.services.security.SecurityService;
+import uk.co.bbr.services.security.UserService;
+import uk.co.bbr.services.security.dao.SiteUserDao;
+import uk.co.bbr.services.security.ex.AuthenticationFailedException;
+import uk.co.bbr.web.LoginMixin;
+import uk.co.bbr.web.security.support.TestUser;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Covers the profile page for users whose account has a stripe email recorded,
+ * where the stripe lookup can return nothing (stale email) or a subscription
+ * with no current period end. Both cases previously caused a 500.
+ */
+@ActiveProfiles("test")
+@SpringBootTest(properties = {  "spring.config.location=classpath:test-application.yml",
+        "spring.datasource.url=jdbc:h2:mem:profile-stripe-web-tests-h2;DB_CLOSE_DELAY=-1;MODE=MSSQLServer;DATABASE_TO_LOWER=TRUE"},
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ProfileStripeWebTests implements LoginMixin {
+
+    private static Optional<Subscription> stubbedSubscription = Optional.empty();
+
+    @TestConfiguration
+    static class StubStripeConfiguration {
+        @Bean
+        @Primary
+        public StripeService stubStripeService() {
+            return new StripeService() {
+                @Override
+                public boolean isSubscriptionActive(SiteUserDao user) {
+                    return stubbedSubscription.isPresent();
+                }
+
+                @Override
+                public LocalDate subscriptionExpiryDate(SiteUserDao user) {
+                    return null;
+                }
+
+                @Override
+                public String fetchEmailFromCheckoutSession(String stripeCheckoutSessionId) {
+                    return null;
+                }
+
+                @Override
+                public Optional<Subscription> getActiveSubscription(SiteUserDao user) {
+                    return stubbedSubscription;
+                }
+            };
+        }
+    }
+
+    @Autowired private SecurityService securityService;
+    @Autowired private JwtService jwtService;
+    @Autowired private UserService userService;
+    @Autowired private CsrfTokenRepository csrfTokenRepository;
+    @Autowired private RestTemplate restTemplate;
+    @LocalServerPort private int port;
+
+    @BeforeAll
+    void setupUser() throws AuthenticationFailedException {
+        this.securityService.createUser(TestUser.TEST_PRO.getUsername(), TestUser.TEST_PRO.getPassword(), TestUser.TEST_PRO.getEmail());
+        this.securityService.makeUserPro(TestUser.TEST_PRO.getUsername());
+
+        loginTestUser(this.securityService, this.jwtService, TestUser.TEST_PRO);
+        SiteUserDao user = this.userService.fetchUserByUsercode(TestUser.TEST_PRO.getUsername()).get();
+        user.setStripeEmail("someone@example.com");
+        this.securityService.update(user);
+        logoutTestUser();
+
+        loginTestUserByWeb(TestUser.TEST_PRO, this.restTemplate, this.csrfTokenRepository, this.port);
+    }
+
+    @Test
+    void testProfilePageWorksWhenStripeEmailMatchesNoSubscription() {
+        // arrange - the stored stripe email no longer matches anything in stripe
+        stubbedSubscription = Optional.empty();
+
+        // act
+        String response = this.restTemplate.getForObject("http://localhost:" + this.port + "/profile", String.class);
+
+        // assert - page renders with the upgrade option rather than failing
+        assertNotNull(response);
+        assertTrue(response.contains("User Profile - Brass Band Results</title>"));
+    }
+
+    @Test
+    void testProfilePageWorksWhenSubscriptionHasNoPeriodEnd() {
+        // arrange - an active subscription with no current period end
+        Subscription subscription = new Subscription();
+        subscription.setCurrentPeriodEnd(null);
+        stubbedSubscription = Optional.of(subscription);
+
+        // act
+        String response = this.restTemplate.getForObject("http://localhost:" + this.port + "/profile", String.class);
+
+        // assert
+        assertNotNull(response);
+        assertTrue(response.contains("User Profile - Brass Band Results</title>"));
+    }
+
+    @Test
+    void testProfilePageShowsExpiryWhenSubscriptionHasPeriodEnd() {
+        // arrange - an active subscription running until well into the future,
+        // midday mid-year so the rendered date is 2100 in any server timezone
+        Subscription subscription = new Subscription();
+        subscription.setCurrentPeriodEnd(4118126400L); // 1 Jul 2100, 12:00 UTC
+        stubbedSubscription = Optional.of(subscription);
+
+        // act
+        String response = this.restTemplate.getForObject("http://localhost:" + this.port + "/profile", String.class);
+
+        // assert
+        assertNotNull(response);
+        assertTrue(response.contains("runs until"));
+        assertTrue(response.contains("2100"));
+    }
+}


### PR DESCRIPTION
**What I hit:** I had a Pro account for a while; it lapsed. Logged in, clicking "Upgrade to pro and remove ads" (→ `/profile`) gives me the "Snap, it broke!" 500 page — so as a lapsed subscriber I can't actually reach the upgrade button to re-subscribe.

**Why it happens:** `/profile` calls `fetchSubscription` for any user with a `stripe_email` recorded. In `StripeServiceImpl.getActiveSubscription`, when Stripe returns no customer for that email — a lapsed/legacy subscriber, or an email from before a Stripe account change — this line throws:

```java
user.setStripeCustomer(customers.getData().get(0).getId());   // IndexOutOfBoundsException
```

`IndexOutOfBoundsException` isn't a `StripeException`, so it escapes the catch block and the request 500s. Anyone in this state is locked out of the whole profile area, including the upgrade flow.

**What this PR does:**

- Guards the empty customer list — no matching Stripe customer now means "no subscription" instead of a 500.
- Guards a second crash on the same page: a subscription with a null `current_period_end` NPE'd in `ProfileController` before this fix.
- Fixes `subscriptionExpiryDate` interpreting Stripe's epoch-seconds as epoch-millis (dates would render in 1970).
- Adds `ProfileStripeWebTests`, which stub `StripeService` (same `@TestConfiguration` pattern as `TestLocationService`) to cover the stale-email case, the null period-end case, and the expiry display for an active subscriber.

Full test suite is green with these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016m3sgr2jgbcjmnHuosmP4M
